### PR TITLE
[CHG] Allow expiration date for cc to come thru

### DIFF
--- a/lib/authorize_net/cim/transaction.rb
+++ b/lib/authorize_net/cim/transaction.rb
@@ -223,6 +223,7 @@ module AuthorizeNet::CIM
       @type = Type::CIM_GET_PAYMENT
       handle_payment_profile_id(payment_profile_id)
       handle_profile_id(profile_id)
+      set_fields(:unmask_expiration_date => true)
       make_request
     end
     

--- a/lib/authorize_net/fields.rb
+++ b/lib/authorize_net/fields.rb
@@ -490,7 +490,8 @@ module AuthorizeNet
       
       GET_PAYMENT_FIELDS = [
         CUSTOMER_PROFILE_ID_FIELDS,
-        CUSTOMER_PAYMENT_PROFILE_ID_FIELDS
+        CUSTOMER_PAYMENT_PROFILE_ID_FIELDS,
+        {:unmaskExpirationDate => :unmask_expiration_date}
       ]
       
       GET_ADDRESS_FIELDS = [


### PR DESCRIPTION
The api call for payment details has a flag to allow the exp date to
be unmasked, but it's off by default.  This turns it on as we will
always need the expiration date back from the api.